### PR TITLE
Updated SaxesOptions typings

### DIFF
--- a/lib/saxes.d.ts
+++ b/lib/saxes.d.ts
@@ -4,7 +4,9 @@ declare namespace saxes {
   export interface SaxesOptions {
     xmlns?: boolean;
     position?: boolean;
+    fragment?: boolean;
     fileName?: string;
+    additionalNamespaces?: Record<string, string>;
   }
 
   export interface XMLDecl {


### PR DESCRIPTION
SaxesOptions was missing fragment and additionalNamespaces. This pull requests fixes that.