### PR TITLE
Fix typings

### DIFF
--- a/lib/saxes.d.ts
+++ b/lib/saxes.d.ts
@@ -30,7 +30,7 @@ declare namespace saxes {
     uri: string;
     attributes: Record<string, SaxesAttribute> | Record<string, string>;
     ns: Record<string, string>;
-    selfClosing: boolean;
+    isSelfClosing: boolean;
   }
 
   export class SaxesParser {

--- a/lib/saxes.js
+++ b/lib/saxes.js
@@ -179,7 +179,7 @@ function nsMappingCheck(parser, mapping) {
  *
  * @property {Object.<string, string>} ns The namespace bindings in effect.
  *
- * @property {boolean} selfClosing Whether the tag is
+ * @property {boolean} isSelfClosing Whether the tag is
  * self-closing (e.g. ``<foo/>``).
  *
  */


### PR DESCRIPTION
This PR renames all occurrences of `selfClosing` to `isSelfClosing`.

Had a good fight with my editor because of this :laughing: 