### PR TITLE
Do not prefix errors by "undefined:" when fileName is not given

### DIFF
--- a/lib/saxes.js
+++ b/lib/saxes.js
@@ -487,7 +487,7 @@ class SaxesParser {
    * check for issues that are outside the scope of this project and can report
    * errors.
    *
-   * @param {String} er The error to report.
+   * @param {string} er The error to report.
    *
    * @returns this
    */

--- a/lib/saxes.js
+++ b/lib/saxes.js
@@ -256,8 +256,7 @@ const FORBIDDEN_BRACKET_BRACKET = 2;
  * @property {boolean} [position] Whether to track positions. Unset means
  * ``true``.
  *
- * @property {string} [fileName] A file name to use for error reporting. Leaving
- * this unset will report a file name of "undefined". "File name" is a loose
+ * @property {string} [fileName] A file name to use for error reporting. "File name" is a loose
  * concept. You could use a URL to some resource, or any descriptive name you
  * like.
  */
@@ -493,8 +492,15 @@ class SaxesParser {
    * @returns this
    */
   fail(er) {
-    const message = (this.trackPosition) ?
-          `${this.fileName}:${this.line}:${this.column}: ${er}` : er;
+    const fragments = [];
+    if (this.fileName) {
+      fragments.push(this.fileName);
+    }
+    if (this.trackPosition) {
+      fragments.push(this.line, this.column);
+    }
+    const message = fragments.length > 0 ?
+      `${fragments.join(":")}: ${er}` : er;
 
     this.onerror(new Error(message));
     return this;

--- a/lib/saxes.js
+++ b/lib/saxes.js
@@ -492,16 +492,17 @@ class SaxesParser {
    * @returns this
    */
   fail(er) {
-    const fragments = [];
-    if (this.fileName) {
-      fragments.push(this.fileName);
-    }
+    let message = this.fileName || "";
     if (this.trackPosition) {
-      fragments.push(this.line, this.column);
+      if (message.length > 0) {
+        message += ":";
+      }
+      message += `${this.line}:${this.column}`;
     }
-    const message = fragments.length > 0 ?
-      `${fragments.join(":")}: ${er}` : er;
-
+    if (message.length > 0) {
+      message += ": ";
+    }
+    message += er;
     this.onerror(new Error(message));
     return this;
   }

--- a/lib/saxes.js
+++ b/lib/saxes.js
@@ -488,7 +488,7 @@ class SaxesParser {
    * check for issues that are outside the scope of this project and can report
    * errors.
    *
-   * @param {Error} er The error to report.
+   * @param {String} er The error to report.
    *
    * @returns this
    */

--- a/test/attribute-no-space.js
+++ b/test/attribute-no-space.js
@@ -6,7 +6,7 @@ require(".").test({
   xml: "<root attr1=\"first\"attr2=\"second\"/>",
   expect: [
     ["opentagstart", { name: "root", attributes: {} }],
-    ["error", "undefined:1:20: no whitespace between attributes."],
+    ["error", "1:20: no whitespace between attributes."],
     ["opentag", { name: "root", attributes: { attr1: "first", attr2: "second" }, isSelfClosing: true }],
     ["closetag", { name: "root", attributes: { attr1: "first", attr2: "second" }, isSelfClosing: true }],
   ],

--- a/test/attribute-unquoted.js
+++ b/test/attribute-unquoted.js
@@ -4,7 +4,7 @@ require(".").test({
   name: "attribute unquoted",
   expect: [
     ["opentagstart", { name: "root", attributes: {}, ns: {} }],
-    ["error", "undefined:1:14: unquoted attribute value."],
+    ["error", "1:14: unquoted attribute value."],
     ["opentag", {
       name: "root",
       attributes: {

--- a/test/bad-entities.js
+++ b/test/bad-entities.js
@@ -6,7 +6,7 @@ require(".").test({
   expect: [
     ["opentagstart", { name: "r", attributes: {} }],
     ["opentag", { name: "r", attributes: {}, isSelfClosing: false }],
-    ["error", "undefined:1:5: empty entity name."],
+    ["error", "1:5: empty entity name."],
     ["text", "&;"],
     ["closetag", { name: "r", attributes: {}, isSelfClosing: false }],
   ],
@@ -18,7 +18,7 @@ require(".").test({
   expect: [
     ["opentagstart", { name: "r", attributes: {} }],
     ["opentag", { name: "r", attributes: {}, isSelfClosing: false }],
-    ["error", "undefined:1:6: malformed character entity."],
+    ["error", "1:6: malformed character entity."],
     ["text", "&#;"],
     ["closetag", { name: "r", attributes: {}, isSelfClosing: false }],
   ],
@@ -30,7 +30,7 @@ require(".").test({
   expect: [
     ["opentagstart", { name: "r", attributes: {} }],
     ["opentag", { name: "r", attributes: {}, isSelfClosing: false }],
-    ["error", "undefined:1:7: malformed character entity."],
+    ["error", "1:7: malformed character entity."],
     ["text", "&#x;"],
     ["closetag", { name: "r", attributes: {}, isSelfClosing: false }],
   ],

--- a/test/bom.js
+++ b/test/bom.js
@@ -28,7 +28,7 @@ require(".").test({
   name: "BOM outside of root, but not initial",
   xml: " \uFEFF<P></P>",
   expect: [
-    ["error", "undefined:1:2: text data outside of root node."],
+    ["error", "1:2: text data outside of root node."],
     ["text", "\uFEFF"],
     ["opentagstart", { name: "P", attributes: {} }],
     ["opentag", { name: "P", attributes: {}, isSelfClosing: false }],
@@ -41,7 +41,7 @@ require(".").test({
   name: "multiple BOMs",
   xml: "\uFEFF\uFEFF<P></P>",
   expect: [
-    ["error", "undefined:1:2: text data outside of root node."],
+    ["error", "1:2: text data outside of root node."],
     ["text", "\uFEFF"],
     ["opentagstart", { name: "P", attributes: {} }],
     ["opentag", { name: "P", attributes: {}, isSelfClosing: false }],

--- a/test/close-without-open.js
+++ b/test/close-without-open.js
@@ -6,8 +6,8 @@ test({
   name: "close a tag that was not opened",
   xml: "</root>",
   expect: [
-    ["error", "undefined:1:7: unmatched closing tag: root."],
-    ["error", "undefined:1:7: document must contain a root element."],
+    ["error", "1:7: unmatched closing tag: root."],
+    ["error", "1:7: document must contain a root element."],
     ["text", "</root>"],
   ],
   opt: {

--- a/test/duplicate-attribute.js
+++ b/test/duplicate-attribute.js
@@ -8,7 +8,7 @@ require(".").test({
       name: "span",
       attributes: {},
     }],
-    ["error", "undefined:1:28: duplicate attribute: id."],
+    ["error", "1:28: duplicate attribute: id."],
     ["opentag", {
       name: "span",
       attributes: { id: "there" },

--- a/test/entity-nan.js
+++ b/test/entity-nan.js
@@ -6,7 +6,7 @@ require(".").test({
   expect: [
     ["opentagstart", { name: "r", attributes: {} }],
     ["opentag", { name: "r", attributes: {}, isSelfClosing: false }],
-    ["error", "undefined:1:9: malformed character entity."],
+    ["error", "1:9: malformed character entity."],
     ["text", "&#NaN;"],
     ["closetag", { name: "r", attributes: {}, isSelfClosing: false }],
   ],

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,39 @@
+"use strict";
+
+require(".").test({
+  name: "without fileName",
+  xml: "<doc>",
+  expect: [
+    ["opentagstart", { name: "doc", attributes: {} }],
+    ["opentag", { name: "doc", isSelfClosing: false, attributes: {} }],
+    ["error", "1:5: unclosed tag: doc"],
+  ],
+  opt: {},
+});
+
+require(".").test({
+  name: "with fileName",
+  xml: "<doc>",
+  expect: [
+    ["opentagstart", { name: "doc", attributes: {} }],
+    ["opentag", { name: "doc", isSelfClosing: false, attributes: {} }],
+    ["error", "foobar.xml:1:5: unclosed tag: doc"],
+  ],
+  opt: {
+    fileName: "foobar.xml",
+  },
+});
+
+require(".").test({
+  name: "with fileName, when not tracking position position",
+  xml: "<doc>",
+  expect: [
+    ["opentagstart", { name: "doc", attributes: {} }],
+    ["opentag", { name: "doc", isSelfClosing: false, attributes: {} }],
+    ["error", "foobar.xml: unclosed tag: doc"],
+  ],
+  opt: {
+    fileName: "foobar.xml",
+    position: false,
+  },
+});

--- a/test/errors.js
+++ b/test/errors.js
@@ -12,6 +12,19 @@ require(".").test({
 });
 
 require(".").test({
+  name: "without fileName, when not tracking position position",
+  xml: "<doc>",
+  expect: [
+    ["opentagstart", { name: "doc", attributes: {} }],
+    ["opentag", { name: "doc", isSelfClosing: false, attributes: {} }],
+    ["error", "unclosed tag: doc"],
+  ],
+  opt: {
+    position: false,
+  },
+});
+
+require(".").test({
   name: "with fileName",
   xml: "<doc>",
   expect: [

--- a/test/fragments.js
+++ b/test/fragments.js
@@ -191,7 +191,7 @@ describe("fragments", () => {
         ns: {},
         isSelfClosing: false,
       }],
-      ["error", "undefined:1:31: unclosed tag: more"],
+      ["error", "1:31: unclosed tag: more"],
       ["text", "2"],
     ],
     opt: {

--- a/test/issue-86.js
+++ b/test/issue-86.js
@@ -33,11 +33,11 @@ require(".").test({
     ],
     [
       "error",
-      "undefined:1:19: text data outside of root node.",
+      "1:19: text data outside of root node.",
     ],
     [
       "error",
-      "undefined:1:20: unexpected end.",
+      "1:20: unexpected end.",
     ],
     [
       "text",

--- a/test/trailing-attribute-no-value.js
+++ b/test/trailing-attribute-no-value.js
@@ -5,7 +5,7 @@ require(".").test({
   xml: "<root attrib></root>",
   expect: [
     ["opentagstart", { name: "root", attributes: {} }],
-    ["error", "undefined:1:13: attribute without value."],
+    ["error", "1:13: attribute without value."],
     ["opentag", { name: "root", attributes: { attrib: "attrib" }, isSelfClosing: false }],
     ["closetag", { name: "root", attributes: { attrib: "attrib" }, isSelfClosing: false }],
   ],

--- a/test/trailing-non-whitespace.js
+++ b/test/trailing-non-whitespace.js
@@ -19,7 +19,7 @@ require(".").test({
       attributes: {},
       isSelfClosing: false,
     }],
-    ["error", "undefined:1:36: text data outside of root node."],
+    ["error", "1:36: text data outside of root node."],
     ["text", " to monkey land"],
     ["end", undefined],
     ["ready", undefined],

--- a/test/unclosed-root.js
+++ b/test/unclosed-root.js
@@ -21,7 +21,7 @@ require(".").test({
     ],
     [
       "error",
-      "undefined:1:6: unclosed tag: root",
+      "1:6: unclosed tag: root",
     ],
   ],
   opt: {},

--- a/test/wrong-cdata-closure.js
+++ b/test/wrong-cdata-closure.js
@@ -19,7 +19,7 @@ describe("wrong cdata closure", () => {
         isSelfClosing: false,
       }],
       ["error",
-       "undefined:1:19: the string \"]]>\" is disallowed in char data."],
+       "1:19: the string \"]]>\" is disallowed in char data."],
       ["text", "somethingx]]>moo"],
       ["closetag", {
         name: "span",
@@ -51,7 +51,7 @@ describe("wrong cdata closure", () => {
         isSelfClosing: false,
       }],
       ["error",
-       "undefined:1:19: the string \"]]>\" is disallowed in char data."],
+       "1:19: the string \"]]>\" is disallowed in char data."],
       ["text", "somethingx]]>moo"],
       ["closetag", {
         name: "span",
@@ -83,7 +83,7 @@ describe("wrong cdata closure", () => {
         isSelfClosing: false,
       }],
       ["error",
-       "undefined:1:19: the string \"]]>\" is disallowed in char data."],
+       "1:19: the string \"]]>\" is disallowed in char data."],
       ["text", "somethingx]]>moo"],
       ["closetag", {
         name: "span",

--- a/test/xml-declaration.js
+++ b/test/xml-declaration.js
@@ -9,7 +9,7 @@ describe("xml declaration", () => {
     name: "empty declaration",
     xml: "<?xml?><root/>",
     expect: [
-      ["error", "undefined:1:7: XML declaration must contain a version."],
+      ["error", "1:7: XML declaration must contain a version."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",
@@ -45,7 +45,7 @@ describe("xml declaration", () => {
     name: "version without value",
     xml: "<?xml version?><root/>",
     expect: [
-      ["error", "undefined:1:15: XML declaration is incomplete."],
+      ["error", "1:15: XML declaration is incomplete."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",
@@ -81,7 +81,7 @@ describe("xml declaration", () => {
     name: "version without value",
     xml: "<?xml version=?><root/>",
     expect: [
-      ["error", "undefined:1:16: XML declaration is incomplete."],
+      ["error", "1:16: XML declaration is incomplete."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",
@@ -117,8 +117,8 @@ describe("xml declaration", () => {
     name: "unquoted value",
     xml: "<?xml version=a?><root/>",
     expect: [
-      ["error", "undefined:1:15: value must be quoted."],
-      ["error", "undefined:1:17: XML declaration is incomplete."],
+      ["error", "1:15: value must be quoted."],
+      ["error", "1:17: XML declaration is incomplete."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",
@@ -154,7 +154,7 @@ describe("xml declaration", () => {
     name: "unterminated value",
     xml: "<?xml version=\"a?><root/>",
     expect: [
-      ["error", "undefined:1:18: XML declaration is incomplete."],
+      ["error", "1:18: XML declaration is incomplete."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",
@@ -190,7 +190,7 @@ describe("xml declaration", () => {
     name: "bad version",
     xml: "<?xml version=\"a\"?><root/>",
     expect: [
-      ["error", "undefined:1:17: version number must match /^1\\.[0-9]+$/."],
+      ["error", "1:17: version number must match /^1\\.[0-9]+$/."],
       ["opentagstart", { name: "root", attributes: {}, ns: {} }],
       [
         "opentag",

--- a/test/xml-internal-entities.js
+++ b/test/xml-internal-entities.js
@@ -38,7 +38,7 @@ for (const entity in entitiesToTest) {
 
     attributeErrors.push([
       "error",
-      `undefined:1:${pos}: ${entity[0] === "#" ? "malformed character entity." :
+      `1:${pos}: ${entity[0] === "#" ? "malformed character entity." :
 "disallowed character in entity name."}`,
     ]);
     myAttributes[attribName] = `&${entity};`;

--- a/test/xmlns-unbound.js
+++ b/test/xmlns-unbound.js
@@ -17,7 +17,7 @@ describe("xmlns unbound prefixes", () => {
       ],
       [
         "error",
-        "undefined:1:15: unbound namespace prefix: \"unbound\".",
+        "1:15: unbound namespace prefix: \"unbound\".",
       ],
       [
         "opentag",
@@ -127,7 +127,7 @@ describe("xmlns unbound prefixes", () => {
       ],
       [
         "error",
-        "undefined:1:28: unbound namespace prefix: \"unbound\".",
+        "1:28: unbound namespace prefix: \"unbound\".",
       ],
       [
         "opentag",

--- a/test/xmlns-xml-default-prefix.js
+++ b/test/xmlns-xml-default-prefix.js
@@ -113,7 +113,7 @@ describe("xml default prefix", () => {
       ],
       [
         "error",
-        "undefined:1:27: xml prefix must be bound to \
+        "1:27: xml prefix must be bound to \
 http://www.w3.org/XML/1998/namespace.",
       ],
       [


### PR DESCRIPTION
Also, make sure that the `fileName` is reported even when not tracking positions.

The `undefined:` thing looked like an error to me when I first saw a parse error coming out of jsdom (hence https://github.com/jsdom/jsdom/pull/2630). Now that I look at the code, I see that it's actually explicitly there in the jsdoc. As a user I still think it's weird, so I'm offering this PR :)